### PR TITLE
chore: use triton-python-model for post processing lib

### DIFF
--- a/post/1/model.py
+++ b/post/1/model.py
@@ -12,7 +12,6 @@ class TritonPythonModel(PostKeypointDetectionModel):
         pred_keypoints = inputs[0]
         scores = inputs[1][0]
         scales = inputs[3]  # inputs[2] is bounding box of person, not use yet
-
         kps = []
         scs = []
         for i, s in enumerate(scores):
@@ -21,4 +20,4 @@ class TritonPythonModel(PostKeypointDetectionModel):
             kps.append(pred_keypoints[i])
             scs.append(s)
         kps = [p / scales[0] for p in kps]
-        return [np.ndarray(kps), np.ndarray(scs)]
+        return [np.array(kps), np.array(scs)]

--- a/post/1/model.py
+++ b/post/1/model.py
@@ -1,105 +1,24 @@
+from typing import List, Tuple
+
 import numpy as np
-import json
-import sys
-import os
+from triton_python_model.task.keypoint import PostKeypointDetectionModel
 
-from pathlib import Path
-from typing import List
 
-from triton_python_backend_utils import Tensor, InferenceResponse, \
-    get_input_tensor_by_name, InferenceRequest, get_input_config_by_name, \
-    get_output_config_by_name, triton_string_to_numpy
-
-class TritonPythonModel(object):
+class TritonPythonModel(PostKeypointDetectionModel):
     def __init__(self):
-        self.input_names = {
-            'pred_keypoints': 'pred_keypoints',
-            'pred_scores': 'pred_scores',
-            'pred_boxes': 'pred_boxes',
-            'scale': 'scale',
-        }
-        self.output_names = {
-            'kpoints': 'kpoints',
-            'scores': 'scores'
-        }
+        super().__init__(['pred_keypoints', 'pred_scores', 'pred_boxes', 'scale'], ['kpoints', 'scores'])
 
-    def initialize(self, args):
-        model_config = json.loads(args['model_config'])
+    def post_process_per_image(self, inputs: Tuple[np.ndarray]) -> List[np.ndarray]:
+        pred_keypoints = inputs[0]
+        scores = inputs[1][0]
+        scales = inputs[3]  # inputs[2] is bounding box of person, not use yet
 
-        if 'input' not in model_config:
-            raise ValueError('Input is not defined in the model config')
-
-        input_configs = {k: get_input_config_by_name(
-            model_config, name) for k, name in self.input_names.items()}
-        for k, cfg in input_configs.items():
-            if cfg is None:
-                raise ValueError(
-                    f'Input {self.input_names[k]} is not defined in the model config')
-            if 'dims' not in cfg:
-                raise ValueError(
-                    f'Dims for input {self.input_names[k]} are not defined in the model config')
-            if 'name' not in cfg:
-                raise ValueError(
-                    f'Name for input {self.input_names[k]} is not defined in the model config')
-
-        if 'output' not in model_config:
-            raise ValueError('Output is not defined in the model config')
-
-        output_configs = {k: get_output_config_by_name(
-            model_config, name) for k, name in self.output_names.items()}
-        for k, cfg in output_configs.items():
-            if cfg is None:
-                raise ValueError(
-                    f'Output {self.output_names[k]} is not defined in the model config')
-            if 'dims' not in cfg:
-                raise ValueError(
-                    f'Dims for output {self.output_names[k]} are not defined in the model config')
-            if 'name' not in cfg:
-                raise ValueError(
-                    f'Name for output {self.output_names[k]} is not defined in the model config')
-            if 'data_type' not in cfg:
-                raise ValueError(
-                    f'Data type for output {self.output_names[k]} is not defined in the model config')
-
-        self.output_dtypes = {k: triton_string_to_numpy(
-            cfg['data_type']) for k, cfg in output_configs.items()}
-
-    def execute(self, inference_requests: List[InferenceRequest]) -> List[InferenceResponse]:
-        responses = []
-
-        for request in inference_requests:
-            batch_in = {}
-            for k, name in self.input_names.items():
-                tensor = get_input_tensor_by_name(request, name)
-                if tensor is None:
-                    raise ValueError(f'Input tensor {name} not found ' f'in request {request.request_id()}')
-                batch_in[k] = tensor.as_numpy()  # shape (batch_size, ...)
-
-            batch_out = {k: [] for k, name in self.output_names.items(
-            ) if name in request.requested_output_names()}
-
-            # model only process single image
-            pred_keypoints = batch_in['pred_keypoints'] # result of all images is stacked then only single will be same shape
-            scores = batch_in['pred_scores'][0]
-            scales = batch_in['scale'][0]
-            kps = []
-            scs = []
-            for i, s in enumerate(scores):
-                if s < 0.8: continue
-                kps.append(pred_keypoints[i])
-                scs.append(s)
-            kps = [p/scales[0] for p in kps]
-            batch_out['kpoints'] = kps
-            batch_out['scores'] = scs
-
-            # Format outputs to build an InferenceResponse
-            output_tensors = [Tensor(self.output_names[k], np.asarray(
-                out, dtype=self.output_dtypes[k])) for k, out in batch_out.items()]
-
-            # TODO: should set error field from InferenceResponse constructor to handle errors
-            # https://github.com/triton-inference-server/python_backend#execute
-            # https://github.com/triton-inference-server/python_backend#error-handling
-            response = InferenceResponse(output_tensors)
-            responses.append(response)
-
-        return responses        
+        kps = []
+        scs = []
+        for i, s in enumerate(scores):
+            if s < 0.8:
+                continue
+            kps.append(pred_keypoints[i])
+            scs.append(s)
+        kps = [p / scales[0] for p in kps]
+        return [np.ndarray(kps), np.ndarray(scs)]


### PR DESCRIPTION
Because

- triton-python-model library support wrapper post-processing for handling task

This commit

- use triton-python-model library for post-processing
